### PR TITLE
Lock `datasets` version to 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 transformers
 lightning
 sentencepiece
-datasets
+datasets == 3.6.0
 seqeval
 nltk
 torch


### PR DESCRIPTION
To allow external dataset scripts. 